### PR TITLE
refactor: provide better public API, enforce proxying mode

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,6 +37,7 @@ jobs:
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         file: ./coverage.txt
+      if: github.event_name == 'push'
 
   lint:
     name: Lint

--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ locally:
 ```go
 server := grpc.NewServer(
     grpc.CustomCodec(proxy.Codec()),
-    grpc.UnknownServiceHandler(proxy.TransparentHandler(director)))
+    grpc.UnknownServiceHandler(
+        proxy.TransparentHandler(director),
+        proxy.WithMode(proxy.One2One),
+    ))
 pb_test.RegisterTestServiceServer(server, &testImpl{})
 ```
 

--- a/proxy/examples_test.go
+++ b/proxy/examples_test.go
@@ -25,8 +25,10 @@ func ExampleRegisterService() {
 	// Register a TestService with 4 of its methods explicitly.
 	proxy.RegisterService(server, director,
 		"talos.testproto.TestService",
-		[]string{"PingEmpty", "Ping", "PingError", "PingList"},
-		[]string{"PingList"})
+		proxy.WithMode(proxy.One2Many),
+		proxy.WithMethodNames("PingEmpty", "Ping", "PingError", "PingList"),
+		proxy.WithStreamedMethodNames("PingList"),
+	)
 }
 
 func ExampleTransparentHandler() {

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -6,7 +6,6 @@ package proxy
 
 import (
 	"context"
-	"io"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -20,54 +19,17 @@ var (
 	}
 )
 
-// RegisterService sets up a proxy handler for a particular gRPC service and method.
-// The behaviour is the same as if you were registering a handler method, e.g. from a codegenerated pb.go file.
-//
-// This can *only* be used if the `server` also uses grpcproxy.CodecForServer() ServerOption.
-//
-// streamedMethodNames is only important for one-2-many proxying.
-func RegisterService(server *grpc.Server, director StreamDirector, serviceName string, methodNames []string, streamedMethodNames []string) {
-	streamer := &handler{
-		director:        director,
-		streamedMethods: map[string]struct{}{},
-	}
-
-	for _, methodName := range streamedMethodNames {
-		streamer.streamedMethods["/"+serviceName+"/"+methodName] = struct{}{}
-	}
-
-	fakeDesc := &grpc.ServiceDesc{
-		ServiceName: serviceName,
-		HandlerType: (*interface{})(nil),
-	}
-	for _, m := range methodNames {
-		streamDesc := grpc.StreamDesc{
-			StreamName:    m,
-			Handler:       streamer.handler,
-			ServerStreams: true,
-			ClientStreams: true,
-		}
-		fakeDesc.Streams = append(fakeDesc.Streams, streamDesc)
-	}
-	server.RegisterService(fakeDesc, streamer)
-}
-
-// TransparentHandler returns a handler that attempts to proxy all requests that are not registered in the server.
-// The indented use here is as a transparent proxy, where the server doesn't know about the services implemented by the
-// backends. It should be used as a `grpc.UnknownServiceHandler`.
-//
-// This can *only* be used if the `server` also uses grpcproxy.CodecForServer() ServerOption.
-func TransparentHandler(director StreamDirector) grpc.StreamHandler {
-	streamer := &handler{
-		director:        director,
-		streamedMethods: map[string]struct{}{},
-	}
-	return streamer.handler
+type handlerOptions struct {
+	mode             Mode
+	serviceName      string
+	methodNames      []string
+	streamedMethods  map[string]struct{}
+	streamedDetector StreamedDetectorFunc
 }
 
 type handler struct {
-	director        StreamDirector
-	streamedMethods map[string]struct{}
+	director StreamDirector
+	options  handlerOptions
 }
 
 type backendConnection struct {
@@ -94,11 +56,6 @@ func (s *handler) handler(srv interface{}, serverStream grpc.ServerStream) error
 		return err
 	}
 
-	if len(backends) == 0 {
-		return status.Errorf(codes.Unavailable, "no backend connections for proxying")
-	}
-
-	var establishedConnections int
 	backendConnections := make([]backendConnection, len(backends))
 
 	clientCtx, clientCancel := context.WithCancel(serverStream.Context())
@@ -121,109 +78,22 @@ func (s *handler) handler(srv interface{}, serverStream grpc.ServerStream) error
 		if backendConnections[i].connError != nil {
 			continue
 		}
-
-		establishedConnections++
 	}
 
-	if len(backendConnections) != 1 {
-		return s.handlerMulti(fullMethodName, serverStream, backendConnections)
-	}
-
-	// case of proxying one to one:
-	if backendConnections[0].connError != nil {
-		return backendConnections[0].connError
-	}
-
-	// Explicitly *do not close* s2cErrChan and c2sErrChan, otherwise the select below will not terminate.
-	// Channels do not have to be closed, it is just a control flow mechanism, see
-	// https://groups.google.com/forum/#!msg/golang-nuts/pZwdYRGxCIk/qpbHxRRPJdUJ
-	s2cErrChan := s.forwardServerToClient(serverStream, &backendConnections[0])
-	c2sErrChan := s.forwardClientToServer(&backendConnections[0], serverStream)
-	// We don't know which side is going to stop sending first, so we need a select between the two.
-	for i := 0; i < 2; i++ {
-		select {
-		case s2cErr := <-s2cErrChan:
-			if s2cErr == io.EOF {
-				// this is the happy case where the sender has encountered io.EOF, and won't be sending anymore./
-				// the clientStream>serverStream may continue pumping though.
-				//nolint: errcheck
-				backendConnections[0].clientStream.CloseSend()
-				break
-			} else {
-				// however, we may have gotten a receive error (stream disconnected, a read error etc) in which case we need
-				// to cancel the clientStream to the backend, let all of its goroutines be freed up by the CancelFunc and
-				// exit with an error to the stack
-				return status.Errorf(codes.Internal, "failed proxying s2c: %v", s2cErr)
-			}
-		case c2sErr := <-c2sErrChan:
-			// This happens when the clientStream has nothing else to offer (io.EOF), returned a gRPC error. In those two
-			// cases we may have received Trailers as part of the call. In case of other errors (stream closed) the trailers
-			// will be nil.
-			serverStream.SetTrailer(backendConnections[0].clientStream.Trailer())
-			// c2sErr will contain RPC error from client code. If not io.EOF return the RPC error as server stream error.
-			if c2sErr != io.EOF {
-				return c2sErr
-			}
-			return nil
+	switch s.options.mode {
+	case One2One:
+		if len(backendConnections) != 1 {
+			return status.Errorf(codes.Internal, "one2one proxying can't should have exactly one connection (got %d)", len(backendConnections))
 		}
+
+		return s.handlerOne2One(fullMethodName, serverStream, backendConnections)
+	case One2Many:
+		if len(backendConnections) == 0 {
+			return status.Errorf(codes.Unavailable, "no backend connections for proxying")
+		}
+		return s.handlerOne2Many(fullMethodName, serverStream, backendConnections)
+
+	default:
+		return status.Errorf(codes.Internal, "unsupported proxy mode")
 	}
-	return status.Errorf(codes.Internal, "gRPC proxying should never reach this stage.")
-}
-
-func (s *handler) forwardClientToServer(src *backendConnection, dst grpc.ServerStream) chan error {
-	ret := make(chan error, 1)
-	go func() {
-		f := &frame{}
-		for i := 0; ; i++ {
-			if err := src.clientStream.RecvMsg(f); err != nil {
-				ret <- err // this can be io.EOF which is happy case
-				break
-			}
-
-			var err error
-			f.payload, err = src.backend.AppendInfo(f.payload)
-			if err != nil {
-				ret <- err
-				break
-			}
-
-			if i == 0 {
-				// This is a bit of a hack, but client to server headers are only readable after first client msg is
-				// received but must be written to server stream before the first msg is flushed.
-				// This is the only place to do it nicely.
-				md, err := src.clientStream.Header()
-				if err != nil {
-					ret <- err
-					break
-				}
-				if err := dst.SendHeader(md); err != nil {
-					ret <- err
-					break
-				}
-			}
-			if err := dst.SendMsg(f); err != nil {
-				ret <- err
-				break
-			}
-		}
-	}()
-	return ret
-}
-
-func (s *handler) forwardServerToClient(src grpc.ServerStream, dst *backendConnection) chan error {
-	ret := make(chan error, 1)
-	go func() {
-		f := &frame{}
-		for i := 0; ; i++ {
-			if err := src.RecvMsg(f); err != nil {
-				ret <- err // this can be io.EOF which is happy case
-				break
-			}
-			if err := dst.clientStream.SendMsg(f); err != nil {
-				ret <- err
-				break
-			}
-		}
-	}()
-	return ret
 }

--- a/proxy/handler_one2one.go
+++ b/proxy/handler_one2one.go
@@ -1,0 +1,113 @@
+// Copyright 2017 Michal Witkowski. All Rights Reserved.
+// Copyright 2019 Andrey Smirnov. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package proxy
+
+import (
+	"io"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (s *handler) handlerOne2One(fullMethodName string, serverStream grpc.ServerStream, backendConnections []backendConnection) error {
+	// case of proxying one to one:
+	if backendConnections[0].connError != nil {
+		return backendConnections[0].connError
+	}
+
+	// Explicitly *do not close* s2cErrChan and c2sErrChan, otherwise the select below will not terminate.
+	// Channels do not have to be closed, it is just a control flow mechanism, see
+	// https://groups.google.com/forum/#!msg/golang-nuts/pZwdYRGxCIk/qpbHxRRPJdUJ
+	s2cErrChan := s.forwardServerToClient(serverStream, &backendConnections[0])
+	c2sErrChan := s.forwardClientToServer(&backendConnections[0], serverStream)
+	// We don't know which side is going to stop sending first, so we need a select between the two.
+	for i := 0; i < 2; i++ {
+		select {
+		case s2cErr := <-s2cErrChan:
+			if s2cErr == io.EOF {
+				// this is the happy case where the sender has encountered io.EOF, and won't be sending anymore./
+				// the clientStream>serverStream may continue pumping though.
+				//nolint: errcheck
+				backendConnections[0].clientStream.CloseSend()
+				break
+			} else {
+				// however, we may have gotten a receive error (stream disconnected, a read error etc) in which case we need
+				// to cancel the clientStream to the backend, let all of its goroutines be freed up by the CancelFunc and
+				// exit with an error to the stack
+				return status.Errorf(codes.Internal, "failed proxying s2c: %v", s2cErr)
+			}
+		case c2sErr := <-c2sErrChan:
+			// This happens when the clientStream has nothing else to offer (io.EOF), returned a gRPC error. In those two
+			// cases we may have received Trailers as part of the call. In case of other errors (stream closed) the trailers
+			// will be nil.
+			serverStream.SetTrailer(backendConnections[0].clientStream.Trailer())
+			// c2sErr will contain RPC error from client code. If not io.EOF return the RPC error as server stream error.
+			if c2sErr != io.EOF {
+				return c2sErr
+			}
+			return nil
+		}
+	}
+	return status.Errorf(codes.Internal, "gRPC proxying should never reach this stage.")
+}
+
+func (s *handler) forwardClientToServer(src *backendConnection, dst grpc.ServerStream) chan error {
+	ret := make(chan error, 1)
+	go func() {
+		f := &frame{}
+		for i := 0; ; i++ {
+			if err := src.clientStream.RecvMsg(f); err != nil {
+				ret <- err // this can be io.EOF which is happy case
+				break
+			}
+
+			var err error
+			f.payload, err = src.backend.AppendInfo(f.payload)
+			if err != nil {
+				ret <- err
+				break
+			}
+
+			if i == 0 {
+				// This is a bit of a hack, but client to server headers are only readable after first client msg is
+				// received but must be written to server stream before the first msg is flushed.
+				// This is the only place to do it nicely.
+				md, err := src.clientStream.Header()
+				if err != nil {
+					ret <- err
+					break
+				}
+				if err := dst.SendHeader(md); err != nil {
+					ret <- err
+					break
+				}
+			}
+			if err := dst.SendMsg(f); err != nil {
+				ret <- err
+				break
+			}
+		}
+	}()
+	return ret
+}
+
+func (s *handler) forwardServerToClient(src grpc.ServerStream, dst *backendConnection) chan error {
+	ret := make(chan error, 1)
+	go func() {
+		f := &frame{}
+		for i := 0; ; i++ {
+			if err := src.RecvMsg(f); err != nil {
+				ret <- err // this can be io.EOF which is happy case
+				break
+			}
+			if err := dst.clientStream.SendMsg(f); err != nil {
+				ret <- err
+				break
+			}
+		}
+	}()
+	return ret
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1,0 +1,116 @@
+// Copyright 2017 Michal Witkowski. All Rights Reserved.
+// Copyright 2019 Andrey Smirnov. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+package proxy
+
+import "google.golang.org/grpc"
+
+// Mode specifies proxying mode: one2one (transparent) or one2many (aggregation, error wrapping).
+type Mode int
+
+// Mode constants.
+const (
+	One2One Mode = iota
+	One2Many
+)
+
+// StreamedDetectorFunc reports is gRPC is doing streaming (only for one2many proxying).
+type StreamedDetectorFunc func(fullMethodName string) bool
+
+// Option configures gRPC proxy
+type Option func(*handlerOptions)
+
+// WithMethodNames configures list of method names to proxy for non-transparent handler.
+func WithMethodNames(methodNames ...string) Option {
+	return func(o *handlerOptions) {
+		o.methodNames = append([]string(nil), methodNames...)
+	}
+}
+
+// WithStreamedMethodNames configures list of streamed method names.
+//
+// This is only important for one2many proxying.
+// This option can't be used with TransparentHandler.
+func WithStreamedMethodNames(streamedMethodNames ...string) Option {
+	return func(o *handlerOptions) {
+		o.streamedMethods = map[string]struct{}{}
+
+		for _, methodName := range streamedMethodNames {
+			o.streamedMethods["/"+o.serviceName+"/"+methodName] = struct{}{}
+		}
+
+		o.streamedDetector = func(fullMethodName string) bool {
+			_, exists := o.streamedMethods[fullMethodName]
+
+			return exists
+		}
+	}
+}
+
+// WithStreamedDetector configures a function to detect streamed methods.
+//
+// This is only important for one2many proxying.
+func WithStreamedDetector(detector StreamedDetectorFunc) Option {
+	return func(o *handlerOptions) {
+		o.streamedDetector = detector
+	}
+}
+
+// WithMode sets proxying mode: One2One or One2Many.
+//
+// Default mode is One2One.
+func WithMode(mode Mode) Option {
+	return func(o *handlerOptions) {
+		o.mode = mode
+	}
+}
+
+// RegisterService sets up a proxy handler for a particular gRPC service and method.
+// The behavior is the same as if you were registering a handler method, e.g. from a codegenerated pb.go file.
+//
+// This can *only* be used if the `server` also uses grpc.CustomCodec() ServerOption.
+func RegisterService(server *grpc.Server, director StreamDirector, serviceName string, options ...Option) {
+	streamer := &handler{
+		director: director,
+		options: handlerOptions{
+			serviceName: serviceName,
+		},
+	}
+
+	for _, o := range options {
+		o(&streamer.options)
+	}
+
+	fakeDesc := &grpc.ServiceDesc{
+		ServiceName: serviceName,
+		HandlerType: (*interface{})(nil),
+	}
+	for _, m := range streamer.options.methodNames {
+		streamDesc := grpc.StreamDesc{
+			StreamName:    m,
+			Handler:       streamer.handler,
+			ServerStreams: true,
+			ClientStreams: true,
+		}
+		fakeDesc.Streams = append(fakeDesc.Streams, streamDesc)
+	}
+	server.RegisterService(fakeDesc, streamer)
+}
+
+// TransparentHandler returns a handler that attempts to proxy all requests that are not registered in the server.
+// The indented use here is as a transparent proxy, where the server doesn't know about the services implemented by the
+// backends. It should be used as a `grpc.UnknownServiceHandler`.
+//
+// This can *only* be used if the `server` also uses grpc.CustomCodec() ServerOption.
+func TransparentHandler(director StreamDirector, options ...Option) grpc.StreamHandler {
+	streamer := &handler{
+		director: director,
+	}
+
+	for _, o := range options {
+		o(&streamer.options)
+	}
+
+	return streamer.handler
+}


### PR DESCRIPTION
Provide more clear public API with options, also enforce proxying mode
with options (not by looking at number of backends).

One2one and one2many have some differences: one2one is transparent and
oen2many might inject additional metadata, wrap errors and responses,
etc., so if client expects one2many format, it should get it even with
one upstream.

Also provide method to guess streamed methods via function so any policy
can be implemented (inspecting grpc server description, looking at
method name prefix/suffix, etc.)

No functional changes, just shuffling code around.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>