### PR TITLE
fix: allow mode to be set for each request being proxied

### DIFF
--- a/proxy/director.go
+++ b/proxy/director.go
@@ -99,4 +99,4 @@ func (sb *SingleBackend) BuildError(err error) ([]byte, error) {
 // are invoked. So decisions around authorization, monitoring etc. are better to be handled there.
 //
 // See the rather rich example.
-type StreamDirector func(ctx context.Context, fullMethodName string) ([]Backend, error)
+type StreamDirector func(ctx context.Context, fullMethodName string) (Mode, []Backend, error)

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -20,7 +20,6 @@ var (
 )
 
 type handlerOptions struct {
-	mode             Mode
 	serviceName      string
 	methodNames      []string
 	streamedMethods  map[string]struct{}
@@ -51,7 +50,7 @@ func (s *handler) handler(srv interface{}, serverStream grpc.ServerStream) error
 		return status.Errorf(codes.Internal, "lowLevelServerStream not exists in context")
 	}
 
-	backends, err := s.director(serverStream.Context(), fullMethodName)
+	mode, backends, err := s.director(serverStream.Context(), fullMethodName)
 	if err != nil {
 		return err
 	}
@@ -80,7 +79,7 @@ func (s *handler) handler(srv interface{}, serverStream grpc.ServerStream) error
 		}
 	}
 
-	switch s.options.mode {
+	switch mode {
 	case One2One:
 		if len(backendConnections) != 1 {
 			return status.Errorf(codes.Internal, "one2one proxying can't should have exactly one connection (got %d)", len(backendConnections))

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -57,15 +57,6 @@ func WithStreamedDetector(detector StreamedDetectorFunc) Option {
 	}
 }
 
-// WithMode sets proxying mode: One2One or One2Many.
-//
-// Default mode is One2One.
-func WithMode(mode Mode) Option {
-	return func(o *handlerOptions) {
-		o.mode = mode
-	}
-}
-
 // RegisterService sets up a proxy handler for a particular gRPC service and method.
 // The behavior is the same as if you were registering a handler method, e.g. from a codegenerated pb.go file.
 //


### PR DESCRIPTION
This is critical for us to allow single proxy instance to proxy across
the nodes and down to filesocket listeners.

Signed-off-by: Andrey Smirnov <smirnov.andrey@gmail.com>