### PR TITLE
fix: use io.EOF error when no backend connections are available

### DIFF
--- a/proxy/handler_one2many.go
+++ b/proxy/handler_one2many.go
@@ -315,7 +315,7 @@ func (s *handler) forwardServerToClientsMulti(src grpc.ServerStream, destination
 			}
 
 			if liveDestinations == 0 {
-				ret <- errors.New("no backend connections to forward to are available")
+				ret <- io.EOF
 
 				return
 			}


### PR DESCRIPTION
This better mimicks gRPC behavior when attempting to send on a
connection when receiver closes the connection.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>