### PR TITLE
feat: pass fullMethodName to GetConnection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/talos-systems/grpc-proxy
 
-go 1.18
+go 1.19
 
 require (
 	github.com/golang/protobuf v1.5.2

--- a/proxy/handler.go
+++ b/proxy/handler.go
@@ -63,7 +63,7 @@ func (s *handler) handler(srv interface{}, serverStream grpc.ServerStream) error
 
 		// We require that the backend's returned context inherits from the serverStream.Context().
 		var outgoingCtx context.Context
-		outgoingCtx, backendConnections[i].backendConn, backendConnections[i].connError = backends[i].GetConnection(clientCtx)
+		outgoingCtx, backendConnections[i].backendConn, backendConnections[i].connError = backends[i].GetConnection(clientCtx, fullMethodName)
 
 		if backendConnections[i].connError != nil {
 			continue

--- a/proxy/handler_one2many_test.go
+++ b/proxy/handler_one2many_test.go
@@ -152,7 +152,7 @@ func (b *assertingBackend) String() string {
 	return fmt.Sprintf("backend%d", b.i)
 }
 
-func (b *assertingBackend) GetConnection(ctx context.Context) (context.Context, *grpc.ClientConn, error) {
+func (b *assertingBackend) GetConnection(ctx context.Context, fullMethodName string) (context.Context, *grpc.ClientConn, error) {
 	md, _ := metadata.FromIncomingContext(ctx)
 	// Explicitly copy the metadata, otherwise the tests will fail.
 	outCtx := metadata.NewOutgoingContext(ctx, md.Copy())


### PR DESCRIPTION
This provides a way to make decision on passing requests based on the method name.

Signed-off-by: Andrey Smirnov <andrey.smirnov@talos-systems.com>